### PR TITLE
Fix deprecated ungoogled-chromium.yml conf

### DIFF
--- a/ungoogled-chromium.yml
+++ b/ungoogled-chromium.yml
@@ -17,9 +17,9 @@ ingredients:
 script:
   - mkdir -p ./opt/google/chrome/ ; tar xf ../../../ungoogled-chromium_*_linux.tar.xz --strip-components=1 -C ./opt/google/chrome/
   - mkdir -p usr/share/icons/hicolor/48x48/apps/
-  - cp ./opt/google/chrome/product_logo_48.png usr/share/icons/hicolor/48x48/apps/chromium-browser.png
-  - cp usr/share/icons/hicolor/48x48/apps/chromium-browser.png .
-  - wget -c "https://raw.githubusercontent.com/Eloston/ungoogled-chromium/master/packaging/opensuse/sources_template/chromium-browser.desktop" -O ungoogled-chromium.desktop
+  - cp ./opt/google/chrome/product_logo_48.png usr/share/icons/hicolor/48x48/apps/chromium.png
+  - cp usr/share/icons/hicolor/48x48/apps/chromium.png .
+  - wget -c "https://github.com/ungoogled-software/ungoogled-chromium-debian/raw/debian_buster/debian/chromium.desktop" -O ungoogled-chromium.desktop
   - sed -i -e 's|Exec=chromium|Exec=AppRun|g' ungoogled-chromium.desktop
   - sed -i -e 's|Chromium|Chromium (ungoogled)|g' ungoogled-chromium.desktop
   - sed -i -e 's|3.26|3.00|g' opt/google/chrome/chrome


### PR DESCRIPTION
https://raw.githubusercontent.com/Eloston/ungoogled-chromium/master/packaging/opensuse/sources_template/chromium-browser.desktop --> Does not exist anymore, I solved it with that in the debian repo
chromium-browser.png deprecated to chromium.png --> its easy, chromium.desktop from debian repos look for chromium.png icon

That worked for me