### PR TITLE
[Docker] Upgrade build-docker image and packages

### DIFF
--- a/docker-stage1/Dockerfile
+++ b/docker-stage1/Dockerfile
@@ -1,13 +1,13 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
-RUN apt-get update && apt-get -y upgrade
+RUN apt-get update --fix-missing && apt-get -y upgrade
 
 ADD scripts /scripts
 
 RUN /scripts/pre-build.sh
 
-RUN apt-get -y install git debhelper clang-8 lld-8 llvm-8-dev python python3 pkg-config ninja-build python-jinja2 ca-certificates gsettings-desktop-schemas-dev wget flex yasm xvfb wdiff gperf bison valgrind xz-utils x11-apps xfonts-base libglew-dev libgl1-mesa-dev libglu1-mesa-dev libegl1-mesa-dev libgles2-mesa-dev mesa-common-dev libxt-dev libre2-dev libgbm-dev libpng-dev libxss-dev libelf-dev libvpx-dev libpci-dev libcap-dev libdrm-dev libicu-dev libffi-dev libkrb5-dev libexif-dev libflac-dev libudev-dev libopus-dev libwebp-dev libxtst-dev libjpeg-dev libxml2-dev libgtk-3-dev libxslt1-dev liblcms2-dev libpulse-dev libpam0g-dev libsnappy-dev libavutil-dev libavcodec-dev libavformat-dev libglib2.0-dev libasound2-dev libjsoncpp-dev libspeechd-dev libminizip-dev libhunspell-dev libusb-1.0-0-dev libopenjp2-7-dev libmodpbase64-dev libnss3-dev libnspr4-dev libcups2-dev libevent-dev libjs-jquery libjs-jquery-flot libgcrypt20-dev libva-dev fonts-ipafont-gothic fonts-ipafont-mincho uuid-dev nodejs xcb-proto python-xcbgen && \
-  update-alternatives --install /usr/bin/clang clang /usr/bin/clang-8 800     && \
-  update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-8 800 && \
-  update-alternatives --install /usr/bin/llvm-ar llvm-ar /usr/bin/llvm-ar-8 800 && \
-  update-alternatives --install /usr/bin/llvm-nm llvm-nm /usr/bin/llvm-nm-8 800
+RUN apt-get install -y apt-utils && apt-get -y --no-install-recommends install git debhelper clang-10 lld-10 llvm-10-dev python python3 pkg-config ninja-build python-jinja2 ca-certificates gsettings-desktop-schemas-dev wget flex yasm xvfb wdiff gperf bison valgrind xz-utils x11-apps xfonts-base libglew-dev libgl1-mesa-dev libglu1-mesa-dev libegl1-mesa-dev libgles2-mesa-dev mesa-common-dev libxt-dev libre2-dev libgbm-dev libpng-dev libxss-dev libelf-dev libvpx-dev libpci-dev libcap-dev libdrm-dev libicu-dev libffi-dev libkrb5-dev libexif-dev libflac-dev libudev-dev libopus-dev libwebp-dev libxtst-dev libjpeg-dev libxml2-dev libgtk-3-dev libxslt1-dev liblcms2-dev libpulse-dev libpam0g-dev libsnappy-dev libavutil-dev libavcodec-dev libavformat-dev libglib2.0-dev libasound2-dev libjsoncpp-dev libspeechd-dev libminizip-dev libhunspell-dev libusb-1.0-0-dev libopenjp2-7-dev libmodpbase64-dev libnss3-dev libnspr4-dev libcups2-dev libevent-dev libjs-jquery libjs-jquery-flot libgcrypt20-dev libva-dev fonts-ipafont-gothic fonts-ipafont-mincho uuid-dev nodejs xcb-proto python3-xcbgen python-setuptools libx11-xcb-dev libxcb-dri3-dev && \
+  update-alternatives --install /usr/bin/clang clang /usr/bin/clang-10 800 && \
+  update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-10 800 && \
+  update-alternatives --install /usr/bin/llvm-ar llvm-ar /usr/bin/llvm-ar-10 800 && \
+  update-alternatives --install /usr/bin/llvm-nm llvm-nm /usr/bin/llvm-nm-10 800


### PR DESCRIPTION
Builds with docker was failed because old GCC, LLVM packages. I used newer Ubuntu image and LLVM 10 for a success build of `85.0.4183.83-2`. Also added some dependencies.

resolves #62 