### PR TITLE
Update to ungoogled-chromium 86.0.4240.80-1

### DIFF
--- a/patches/debian_buster/arm/skia-aarch64-buildfix.patch
+++ b/patches/debian_buster/arm/skia-aarch64-buildfix.patch
@@ -1,6 +1,6 @@
 --- a/third_party/skia/src/opts/SkRasterPipeline_opts.h
 +++ b/third_party/skia/src/opts/SkRasterPipeline_opts.h
-@@ -983,7 +983,7 @@ SI F approx_powf(F x, F y) {
+@@ -978,7 +978,7 @@ SI F approx_powf(F x, F y) {
  }
  
  SI F from_half(U16 h) {
@@ -9,7 +9,7 @@
      && !defined(SK_BUILD_FOR_GOOGLE3)  // Temporary workaround for some Google3 builds.
      return vcvt_f32_f16(h);
  
-@@ -1004,7 +1004,7 @@ SI F from_half(U16 h) {
+@@ -999,7 +999,7 @@ SI F from_half(U16 h) {
  }
  
  SI U16 to_half(F f) {

--- a/patches/debian_buster/disable/installer.patch
+++ b/patches/debian_buster/disable/installer.patch
@@ -3,7 +3,7 @@ author: Michael Gilbert <mgilbert@debian.org>
 
 --- a/BUILD.gn
 +++ b/BUILD.gn
-@@ -70,7 +70,6 @@ group("gn_all") {
+@@ -71,7 +71,6 @@ group("gn_all") {
      "//base:base_perftests",
      "//base:base_unittests",
      "//base/util:base_util_unittests",

--- a/patches/debian_buster/disable/swiftshader.patch
+++ b/patches/debian_buster/disable/swiftshader.patch
@@ -3,7 +3,7 @@ author: Michael Gilbert <mgilbert@debian.org>
 
 --- a/BUILD.gn
 +++ b/BUILD.gn
-@@ -493,7 +493,7 @@ group("gn_all") {
+@@ -488,7 +488,7 @@ group("gn_all") {
      ]
    }
  

--- a/patches/debian_buster/fixes/as-needed.patch
+++ b/patches/debian_buster/fixes/as-needed.patch
@@ -3,7 +3,7 @@ author: Michael Gilbert <mgilbert@debian.org>
 
 --- a/build/config/compiler/BUILD.gn
 +++ b/build/config/compiler/BUILD.gn
-@@ -392,7 +392,7 @@ config("compiler") {
+@@ -396,7 +396,7 @@ config("compiler") {
      if (!using_sanitizer) {
        ldflags += [
          "-Wl,-z,defs",

--- a/patches/debian_buster/fixes/gpu-timeout.patch
+++ b/patches/debian_buster/fixes/gpu-timeout.patch
@@ -4,7 +4,7 @@ bug-debian: http://bugs.debian.org/781940
 
 --- a/gpu/ipc/service/gpu_watchdog_thread.cc
 +++ b/gpu/ipc/service/gpu_watchdog_thread.cc
-@@ -41,7 +41,7 @@ const int kGpuTimeout = 30000;
+@@ -44,7 +44,7 @@ const int kGpuTimeout = 30000;
  // hangs at context creation during startup. See https://crbug.com/918490.
  const int kGpuTimeout = 15000;
  #else

--- a/patches/debian_buster/fixes/widevine-locations.patch
+++ b/patches/debian_buster/fixes/widevine-locations.patch
@@ -9,12 +9,12 @@ Source: https://bazaar.launchpad.net/~chromium-team/chromium-browser/disco-dev/v
 
 --- a/chrome/common/chrome_paths.cc
 +++ b/chrome/common/chrome_paths.cc
-@@ -374,8 +374,17 @@ bool PathProvider(int key, base::FilePat
-       cur = cur.Append(FILE_PATH_LITERAL("pnacl"));
+@@ -377,8 +377,17 @@ bool PathProvider(int key, base::FilePat
        break;
  
--#if defined(OS_LINUX) && BUILDFLAG(BUNDLE_WIDEVINE_CDM)
-+#if defined(OS_LINUX) && BUILDFLAG(ENABLE_WIDEVINE_CDM_COMPONENT)
+ #if (defined(OS_LINUX) || defined(OS_CHROMEOS)) && \
+-    BUILDFLAG(BUNDLE_WIDEVINE_CDM)
++    BUILDFLAG(ENABLE_WIDEVINE_CDM_COMPONENT)
      case chrome::DIR_BUNDLED_WIDEVINE_CDM:
 +      base::PathService::Get(base::DIR_HOME, &cur);
 +      cur = cur.Append(FILE_PATH_LITERAL(".local/lib"))
@@ -28,12 +28,12 @@ Source: https://bazaar.launchpad.net/~chromium-team/chromium-browser/disco-dev/v
        if (!GetComponentDirectory(&cur))
          return false;
  #if !defined(OS_CHROMEOS)
-@@ -384,7 +393,7 @@ bool PathProvider(int key, base::FilePat
-       cur = cur.AppendASCII(kWidevineCdmBaseDirectory);
+@@ -388,7 +397,7 @@ bool PathProvider(int key, base::FilePat
  #endif  // !defined(OS_CHROMEOS)
        break;
--#endif  // defined(OS_LINUX) && BUILDFLAG(BUNDLE_WIDEVINE_CDM)
-+#endif  // defined(OS_LINUX) && BUILDFLAG(ENABLE_WIDEVINE_CDM_COMPONENT)
+ #endif  // (defined(OS_LINUX) || defined(OS_CHROMEOS)) &&
+-        // BUILDFLAG(BUNDLE_WIDEVINE_CDM)
++        // BUILDFLAG(ENABLE_WIDEVINE_CDM_COMPONENT)
  
  #if defined(OS_LINUX) && !defined(OS_CHROMEOS) && \
      BUILDFLAG(ENABLE_WIDEVINE_CDM_COMPONENT)

--- a/patches/debian_buster/warnings/multichar.patch
+++ b/patches/debian_buster/warnings/multichar.patch
@@ -3,8 +3,8 @@ author: Michael Gilbert <mgilbert@debian.org>
 
 --- a/third_party/crashpad/crashpad/BUILD.gn
 +++ b/third_party/crashpad/crashpad/BUILD.gn
-@@ -17,6 +17,7 @@ import("build/test.gni")
- import("util/net/tls.gni")
+@@ -22,6 +22,7 @@ if (crashpad_is_in_chromium) {
+ }
  
  config("crashpad_config") {
 +  cflags = [ "-Wno-multichar" ]

--- a/patches/debian_buster/warnings/printf.patch
+++ b/patches/debian_buster/warnings/printf.patch
@@ -14,7 +14,7 @@ author: Michael Gilbert <mgilbert@debian.org>
  }  // namespace IPC
 --- a/content/browser/web_package/signed_exchange_handler.cc
 +++ b/content/browser/web_package/signed_exchange_handler.cc
-@@ -607,7 +607,7 @@ void SignedExchangeHandler::OnVerifyCert
+@@ -614,7 +614,7 @@ void SignedExchangeHandler::OnVerifyCert
        error_message = base::StringPrintf(
            "CT verification failed. result: %s, policy compliance: %d",
            net::ErrorToShortString(error_code).c_str(),

--- a/patches/inox-patchset/chromium-skia-harmony.patch
+++ b/patches/inox-patchset/chromium-skia-harmony.patch
@@ -1,6 +1,6 @@
 --- a/third_party/skia/src/ports/SkFontHost_FreeType.cpp
 +++ b/third_party/skia/src/ports/SkFontHost_FreeType.cpp
-@@ -128,9 +128,9 @@ public:
+@@ -131,9 +131,9 @@ public:
          : fGetVarDesignCoordinates(nullptr)
          , fGetVarAxisFlags(nullptr)
          , fLibrary(nullptr)

--- a/patches/inox-patchset/fix-cfi-failures-with-unbundled-libxml.patch
+++ b/patches/inox-patchset/fix-cfi-failures-with-unbundled-libxml.patch
@@ -51,7 +51,7 @@
      parser->HandleError(type_, reinterpret_cast<char*>(message_),
 --- a/third_party/blink/renderer/core/xml/xsl_style_sheet_libxslt.cc
 +++ b/third_party/blink/renderer/core/xml/xsl_style_sheet_libxslt.cc
-@@ -195,7 +195,7 @@ void XSLStyleSheet::LoadChildSheets() {
+@@ -196,7 +196,7 @@ void XSLStyleSheet::LoadChildSheets() {
          xmlChar* uri_ref =
              xsltGetNsProp(curr, (const xmlChar*)"href", XSLT_NAMESPACE);
          LoadChildSheet(String::FromUTF8((const char*)uri_ref));
@@ -60,7 +60,7 @@
        } else {
          break;
        }
-@@ -209,7 +209,7 @@ void XSLStyleSheet::LoadChildSheets() {
+@@ -210,7 +210,7 @@ void XSLStyleSheet::LoadChildSheets() {
          xmlChar* uri_ref =
              xsltGetNsProp(curr, (const xmlChar*)"href", XSLT_NAMESPACE);
          LoadChildSheet(String::FromUTF8((const char*)uri_ref));
@@ -69,7 +69,7 @@
        }
        curr = curr->next;
      }
-@@ -298,8 +298,8 @@ xmlDocPtr XSLStyleSheet::LocateStyleshee
+@@ -300,8 +300,8 @@ xmlDocPtr XSLStyleSheet::LocateStyleshee
        xmlChar* child_uri =
            xmlBuildURI((const xmlChar*)import_href.c_str(), base);
        bool equal_ur_is = xmlStrEqual(uri, child_uri);
@@ -100,7 +100,7 @@
 -      xmlFree(base);
 +      free(base);
  
-       ResourceLoaderOptions fetch_options;
+       ResourceLoaderOptions fetch_options(nullptr /* world */);
        fetch_options.initiator_info.name = fetch_initiator_type_names::kXml;
 --- a/third_party/blink/renderer/core/xml/xslt_unicode_sort.cc
 +++ b/third_party/blink/renderer/core/xml/xslt_unicode_sort.cc

--- a/patches/opensuse/system-libdrm.patch
+++ b/patches/opensuse/system-libdrm.patch
@@ -3,7 +3,7 @@
 @@ -22,6 +22,9 @@
  namespace gfx {
  
- #if defined(OS_LINUX)
+ #if defined(OS_LINUX) || defined(OS_CHROMEOS)
 +#ifndef DRM_FORMAT_MOD_INVALID
 +#define DRM_FORMAT_MOD_INVALID ((1ULL<<56) - 1)
 +#endif

--- a/patches/ubuntu/suppress-newer-clang-warning-flags.patch
+++ b/patches/ubuntu/suppress-newer-clang-warning-flags.patch
@@ -4,29 +4,32 @@ Description: Do not use warning flags that require a newer Clang (bionic has 9.0
 
 --- a/build/config/compiler/BUILD.gn
 +++ b/build/config/compiler/BUILD.gn
-@@ -1500,21 +1500,6 @@ config("default_warnings") {
+@@ -1510,11 +1510,6 @@ config("default_warnings") {
+         # Flags NaCl (Clang 3.7) and Xcode 9.2 (Clang clang-900.0.39.2) do not
+         # recognize.
+         cflags += [
+-          # An ABI compat warning we don't care about, https://crbug.com/1102157
+-          # TODO(thakis): Push this to the (few) targets that need it,
+-          # instead of having a global flag.
+-          "-Wno-psabi",
+-
            # Ignore warnings about MSVC optimization pragmas.
            # TODO(thakis): Only for no_chromium_code? http://crbug.com/912662
            "-Wno-ignored-pragma-optimize",
--
--          # TODO(https://crbug.com/989932): Evaluate and possibly enable.
--          "-Wno-implicit-int-float-conversion",
--
--          # TODO(https://crbug.com/999886): Clean up, enable.
--          "-Wno-final-dtor-non-final-class",
--
--          # TODO(https://crbug.com/1016945) Clean up, enable.
--          "-Wno-builtin-assume-aligned-alignment",
--
--          # TODO(https://crbug.com/1028110): Evaluate and possible enable.
--          "-Wno-deprecated-copy",
+@@ -1530,12 +1525,6 @@ config("default_warnings") {
+ 
+           # TODO(https://crbug.com/1028110): Evaluate and possible enable.
+           "-Wno-deprecated-copy",
 -
 -          # TODO(https://crbug.com/1050281): Clean up, enable.
 -          "-Wno-non-c-typedef-for-linkage",
+-
+-          # TODO(https://crbug.com/1114873): Clean up, enable.
+-          "-Wno-string-concatenation",
          ]
  
          cflags_c += [
-@@ -1663,10 +1648,10 @@ config("no_chromium_code") {
+@@ -1684,10 +1673,10 @@ config("no_chromium_code") {
        "-Wno-unused-variable",
      ]
      if (!is_nacl && (current_toolchain == host_toolchain || !use_xcode_clang)) {

--- a/patches/ungoogled-chromium/fix-node-path.patch
+++ b/patches/ungoogled-chromium/fix-node-path.patch
@@ -1,6 +1,6 @@
 --- a/third_party/node/node.py
 +++ b/third_party/node/node.py
-@@ -10,11 +10,12 @@ import sys
+@@ -11,11 +11,12 @@ import os
  
  
  def GetBinaryPath():

--- a/patches/ungoogled-chromium/remove-fcomplete-member-pointers-cflag.patch
+++ b/patches/ungoogled-chromium/remove-fcomplete-member-pointers-cflag.patch
@@ -3,8 +3,8 @@
 
 --- a/build/config/compiler/BUILD.gn
 +++ b/build/config/compiler/BUILD.gn
-@@ -695,14 +695,6 @@ config("compiler") {
-     ldflags += [ "-Wl,--no-rosegment" ]
+@@ -705,14 +705,6 @@ config("compiler") {
+     }
    }
  
 -  # This flag enforces that member pointer base types are complete. It helps


### PR DESCRIPTION
I have compiled ungoogled-chromium 86.0.4240.75 and it is running well. The portablelinux-specific patches did not require any changes for ungoogled-chromium 86.0.4240.80-1.

Note: I believe LLVM 10 or higher is required to build Chromium 86.