### PR TITLE
Update to ungoogled-chromium 87.0.4280.67-1

### DIFF
--- a/patches/debian_buster/disable/swiftshader.patch
+++ b/patches/debian_buster/disable/swiftshader.patch
@@ -3,7 +3,7 @@ author: Michael Gilbert <mgilbert@debian.org>
 
 --- a/BUILD.gn
 +++ b/BUILD.gn
-@@ -488,7 +488,7 @@ group("gn_all") {
+@@ -479,7 +479,7 @@ group("gn_all") {
      ]
    }
  

--- a/patches/debian_buster/fixes/as-needed.patch
+++ b/patches/debian_buster/fixes/as-needed.patch
@@ -3,7 +3,7 @@ author: Michael Gilbert <mgilbert@debian.org>
 
 --- a/build/config/compiler/BUILD.gn
 +++ b/build/config/compiler/BUILD.gn
-@@ -396,7 +396,7 @@ config("compiler") {
+@@ -392,7 +392,7 @@ config("compiler") {
      if (!using_sanitizer) {
        ldflags += [
          "-Wl,-z,defs",

--- a/patches/debian_buster/warnings/enum-compare.patch
+++ b/patches/debian_buster/warnings/enum-compare.patch
@@ -8,11 +8,11 @@ author: Michael Gilbert <mgilbert@debian.org>
    layout->StartRow(views::GridLayout::kFixedSize, 0);
  
 +  int text_style = views::style::STYLE_SECONDARY;
-+  if (controller_->state() == 
++  if (controller_->state() ==
 +      PasswordGenerationPopupController::kOfferGeneration)
 +    text_style = views::style::STYLE_PRIMARY;
    suggestion_label_ = layout->AddView(std::make_unique<views::Label>(
-       controller_->SuggestedText(), ChromeTextContext::CONTEXT_BODY_TEXT_LARGE,
+       controller_->SuggestedText(), views::style::CONTEXT_DIALOG_BODY_TEXT,
 -      controller_->state() ==
 -              PasswordGenerationPopupController::kOfferGeneration
 -          ? views::style::STYLE_PRIMARY

--- a/patches/ubuntu/suppress-newer-clang-warning-flags.patch
+++ b/patches/ubuntu/suppress-newer-clang-warning-flags.patch
@@ -4,7 +4,7 @@ Description: Do not use warning flags that require a newer Clang (bionic has 9.0
 
 --- a/build/config/compiler/BUILD.gn
 +++ b/build/config/compiler/BUILD.gn
-@@ -1510,11 +1510,6 @@ config("default_warnings") {
+@@ -1497,11 +1497,6 @@ config("default_warnings") {
          # Flags NaCl (Clang 3.7) and Xcode 9.2 (Clang clang-900.0.39.2) do not
          # recognize.
          cflags += [
@@ -16,20 +16,17 @@ Description: Do not use warning flags that require a newer Clang (bionic has 9.0
            # Ignore warnings about MSVC optimization pragmas.
            # TODO(thakis): Only for no_chromium_code? http://crbug.com/912662
            "-Wno-ignored-pragma-optimize",
-@@ -1530,12 +1525,6 @@ config("default_warnings") {
+@@ -1517,9 +1512,6 @@ config("default_warnings") {
  
            # TODO(https://crbug.com/1028110): Evaluate and possible enable.
            "-Wno-deprecated-copy",
 -
 -          # TODO(https://crbug.com/1050281): Clean up, enable.
 -          "-Wno-non-c-typedef-for-linkage",
--
--          # TODO(https://crbug.com/1114873): Clean up, enable.
--          "-Wno-string-concatenation",
          ]
  
          cflags_c += [
-@@ -1684,10 +1673,10 @@ config("no_chromium_code") {
+@@ -1668,10 +1660,10 @@ config("no_chromium_code") {
        "-Wno-unused-variable",
      ]
      if (!is_nacl && (current_toolchain == host_toolchain || !use_xcode_clang)) {

--- a/patches/ungoogled-chromium/remove-fcomplete-member-pointers-cflag.patch
+++ b/patches/ungoogled-chromium/remove-fcomplete-member-pointers-cflag.patch
@@ -3,7 +3,7 @@
 
 --- a/build/config/compiler/BUILD.gn
 +++ b/build/config/compiler/BUILD.gn
-@@ -705,14 +705,6 @@ config("compiler") {
+@@ -692,14 +692,6 @@ config("compiler") {
      }
    }
  


### PR DESCRIPTION
Ungoogled-chromium [87.0.4280.66](https://github.com/Zoraver/ungoogled-chromium/tree/43fbd1d76cda2367dbb869e4984ada276833cf5e) compiled and is running well. The changes in Chromium 87.0.4280.67 are minor enough on non-macOS systems that I don't feel like rebuilding ungoogled-chromium-portablelinux to test...