### PR TITLE
Use docker to create the AppImage file

### DIFF
--- a/Dockerfile-stage3
+++ b/Dockerfile-stage3
@@ -1,7 +1,7 @@
 FROM ug-chromium-builder-stage1:latest
 
 RUN apt-get update
-RUN apt-get install -y imagemagick desktop-file-utils binutils
+RUN apt-get install -y imagemagick desktop-file-utils binutils fuse
 
 WORKDIR /data
 

--- a/Dockerfile-stage3
+++ b/Dockerfile-stage3
@@ -1,0 +1,7 @@
+FROM ug-chromium-builder-stage1:latest
+
+RUN apt-get update
+RUN apt-get install -y imagemagick desktop-file-utils binutils
+
+WORKDIR /data
+

--- a/docker-package-appimage.sh
+++ b/docker-package-appimage.sh
@@ -2,5 +2,5 @@ set -ex
 
 docker build --rm -f "Dockerfile-stage3" -t ug-chromium-builder-stage3:latest ./
 
-docker run -ti -v `pwd`:/data ug-chromium-builder-stage3:latest bash -c "./package.appimage.sh.ungoogin"
+docker run --privileged -ti -v `pwd`:/data ug-chromium-builder-stage3:latest bash -c "./package.appimage.sh.ungoogin"
 

--- a/docker-package-appimage.sh
+++ b/docker-package-appimage.sh
@@ -1,0 +1,6 @@
+set -ex
+
+docker build --rm -f "Dockerfile-stage3" -t ug-chromium-builder-stage3:latest ./
+
+docker run -ti -v `pwd`:/data ug-chromium-builder-stage3:latest bash -c "./package.appimage.sh.ungoogin"
+


### PR DESCRIPTION
This PR allows to create the AppImage with Docker.

Not that is only create the env to build the AppImage and does not solves a bug present in the `package.appimage.sh.ungoogin` script (I will file an issue and PR later on as needed).