### PR TITLE
Update the name of the nodejs binary

### DIFF
--- a/patches/debian/system/node.patch
+++ b/patches/debian/system/node.patch
@@ -14,7 +14,7 @@ author: Michael Gilbert <mgilbert@debian.org>
 -    finally:
 -        sys.path = old_sys_path
 -    return node.GetBinaryPath()
-+    return '/usr/bin/nodejs'
++    return '/usr/bin/node'
  
  
  def devtools_root_path():

--- a/patches/debian/system/node2.patch
+++ b/patches/debian/system/node2.patch
@@ -9,7 +9,7 @@
 -    'Linux': ('linux', 'node-linux-x64', 'bin', 'node'),
 -    'Windows': ('win', 'node.exe'),
 -  }[platform.system()])
-+  return '/usr/bin/nodejs'
++  return '/usr/bin/node'
  
  
  def RunNode(cmd_parts, stdout=None):


### PR DESCRIPTION
Based upon the comment https://github.com/ungoogled-software/ungoogled-chromium-portablelinux/issues/99#issuecomment-841898192 and the installed binaries for node on debian 10 and 11 at least:

```
mdedonno @ yoga: ~
$ ls -la /usr/bin/node*
-rwxr-xr-x 1 root root 26616 Apr 21 12:42 /usr/bin/node
lrwxrwxrwx 1 root root     4 Apr 21 12:42 /usr/bin/nodejs -> node
```

the binary location seems to be mainly the `/usr/bin/node` one, with some installations adding a `nodejs` link to the `node` file.

I propose to change the node target to `node` to be more portable than the `nodejs` one.

Based upon my tests with docker images, the binary `/usr/bin/node` seems available for debian, ubuntu, archlinux, centos, alpine, fedora.