### PR TITLE
Automatic portable build

### DIFF
--- a/.github/workflows/guix-pack.yml
+++ b/.github/workflows/guix-pack.yml
@@ -1,0 +1,73 @@
+name: Create portable executable
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '21 5 * * *'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Guix cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/guix
+          key: guix-cache-${{ github.sha }}
+          restore-keys: |
+            guix-cache-
+      - name: Install Guix
+        uses: PromyLOPH/guix-install-action@v1
+      - name: Assert that binary substitute is available
+        # XXX: Currently 'guix weather' fails unless *all* substitute servers have it.
+        run: guix weather --substitute-urls="https://ci.guix.gnu.org" ungoogled-chromium
+      - name: Skip when substitute is unavailable
+        if: ${{ failure() }}
+        run: echo "No binary substitute available, skipping."
+      - name: Download substitutes
+        run: guix build --no-grafts --fallback ungoogled-chromium
+      - name: Install Recutils
+        run: sudo apt-get -q install recutils
+      - name: Export version information
+        run: |
+          echo today=$(date -I) >> $GITHUB_ENV
+          echo version=$(guix show ungoogled-chromium | recsel -P version) >> $GITHUB_ENV
+          echo guix_commit=$(guix describe -f recutils | recsel -e 'name = "guix"' -P commit) >> $GITHUB_ENV
+      - name: Create relocatable pack
+        run: >
+          guix pack --fallback -RR
+          -S /bin=bin
+          --save-provenance
+          --root=ungoogled-chromium-${{ env.version }}.tar.gz
+          ungoogled-chromium
+      - name: Create release notes
+        # Ah yes, shell scripting Markdown with YAML.  What could go wrong?
+        run: |
+          cat > ${{ runner.temp }}/release_notes.md <<'EOF'
+          The tarball below was generated at ${{ env.today }} by [GNU Guix](https://guix.gnu.org) and @github-actions.
+          To use it, run:
+          ```
+          cd /tmp # or anywhere
+          tar -xf ~/Downloads/ungoogled-chromium-${{ env.version }}.tar.gz
+          ./bin/chromium
+          ```
+          It can be reproduced on a Debian-like distribution by running:
+          ```
+          sudo apt install guix
+          guix time-machine --commit=${{ env.guix_commit }} \
+            -- pack -RR -S /bin=bin ungoogled-chromium
+          ```
+          EOF
+      - name: Upload release
+        uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: true
+          artifacts: ungoogled-chromium-${{ env.version }}.tar.gz
+          artifactContentType: application/gzip
+          bodyFile: ${{ runner.temp }}/release_notes.md
+          omitBodyDuringUpdate: false
+          omitName: true
+          omitNameDuringUpdate: true
+          tag: ${{ env.version }}.1
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ Portable Linux builds can run on **any Linux distribution** (that regular Chromi
 
 ## Downloads
 
-[Download binaries from the Contributor Binaries website](//ungoogled-software.github.io/ungoogled-chromium-binaries/).
+An automated build for 64-bit Linux is available in [Releases](//github.com/ungoogled-software/ungoogled-chromium-portablelinux/releases).
+
+Other binaries are available from [the Contributor Binaries website](//ungoogled-software.github.io/ungoogled-chromium-binaries/).
 
 **Source Code**: It is recommended to use a tag via `git checkout` (see building instructions below). You may also use `master`, but it is for development and may not be stable.
 
@@ -16,7 +18,7 @@ Portable Linux builds can run on **any Linux distribution** (that regular Chromi
     ```sh
     # tar -xvf ungoogled-chromium_xxxxxxx.tar.xz -C /opt
     ```
-2. Follow the instructions in `/opt/ungoogled-chromium_xxxxxxx/README`
+2. For the automated release, you can now run `/opt/bin/chromium`.  For contributor binaries, follow instructions in `/opt/ungoogled-chromium_xxxxxxx/README`.
 
 ## Building
 


### PR DESCRIPTION
This PR adds a GitHub action that uploads an automatically generated portable executable that can be extracted and run from anywhere.  It does not depend on anything but `tar`, `gzip` and a 64-bit Linux kernel.

You can see it [in action](https://github.com/mbakke/ungoogled-chromium-portablelinux/actions) at [my fork](https://github.com/mbakke/ungoogled-chromium-portablelinux/releases).

It is implemented as a daily job in order to get security updates, and comes with instructions for reproducing bit-for-bit on a Debian system.

It works by getting the latest available build from Guix's CI service, turning it into a relocatable self-contained tarball, and uploading it to the corresponding tag in this repo.

I don't have a use case for this myself, but it is a frequent request that is easy to solve with Guix. Hence this PR.