### PR TITLE
Fix breakage when AppDir has spaces in its name

### DIFF
--- a/ungoogled-chromium.yml
+++ b/ungoogled-chromium.yml
@@ -25,7 +25,7 @@ script:
   - sed -i -e 's|3.26|3.00|g' opt/google/chrome/chrome
   - cat > ./AppRun <<\EOF
   - #!/bin/sh
-  - HERE=$(dirname $(readlink -f "${0}"))
+  - HERE="$(dirname "$(readlink -f "${0}")")"
   - export LD_LIBRARY_PATH="${HERE}"/usr/lib:$PATH
   - "${HERE}"/opt/google/chrome/chrome --password-store=basic $@
   - EOF


### PR DESCRIPTION
To reproduce:

```
chmod +x ungoogled-chromium_91.0.4472.164-1.1.AppImage
./ungoogled-chromium_91.0.4472.164-1.1.AppImage --appimage-extract
mv squashfs-root "Ungoogled Chromium.AppDir"
./"Ungoogled Chromium.AppDir/AppRun"
```