### PR TITLE
Fix: docker packager

### DIFF
--- a/package/docker-package.sh
+++ b/package/docker-package.sh
@@ -16,6 +16,9 @@ echo "==============================================================="
 
 [ -n "$(ls -A ${ROOT_DIR}/${GIT_SUBMODULE})" ] || git submodule update --init --recursive
 
+# Since AppImages inside Docker require fuze, we will instead extract and run it
+sed -i '54 s/\.\/pkg2appimage \.\/ungoogled-chromium.yaml/\.\/pkg2appimage --appimage-extract-and-run \.\/ungoogled-chromium.yaml/' ${CURRENT_DIR}/package.sh
+
 PACKAGE_START=$(date)
 echo "==============================================================="
 echo "  docker package start at ${BUILD_START}"
@@ -28,3 +31,6 @@ echo "==============================================================="
 echo "  docker package start at ${PACKAGE_START}"
 echo "  docker package end   at ${PACKAGE_END}"
 echo "==============================================================="
+
+# Revert package script
+sed -i '54 s/\.\/pkg2appimage --appimage-extract-and-run \.\/ungoogled-chromium.yaml/\.\/pkg2appimage \.\/ungoogled-chromium.yaml/' ${CURRENT_DIR}/package.sh

--- a/package/package.sh
+++ b/package/package.sh
@@ -48,7 +48,6 @@ rm -rf ${CURRENT_DIR}/${FILE_PREFIX}_linux && xz "${CURRENT_DIR}/${FILE_PREFIX}_
 set +eux
 
 if [ ! -f "./pkg2appimage" ] ; then
-    #wget -c "https://github.com/AppImage/AppImages/raw/master/pkg2appimage" && chmod +x ./pkg2appimage
     wget -c $(wget -q https://api.github.com/repos/AppImageCommunity/pkg2appimage/releases -O - | grep "pkg2appimage-.*-x86_64.AppImage" | grep browser_download_url | head -n 1 | cut -d '"' -f 4)
     mv ./pkg2appimage-*.AppImage ./pkg2appimage && chmod +x ./pkg2appimage
 fi


### PR DESCRIPTION
Current docker packager script was broken due to the changes in `pkg2appimage`.
Even the originally used(commented in `package.sh`) raw script is now using appimages inside it.
In order to be able to use an `AppImage` inside docker, `fuse` must be setup, which should be avoided,
as it increases container privileges.
Instead, this PR is using `sed` to modify `package.sh` inline, appending `--appimage-extract-and-run` flag
to `pkg2appimage`, so its extracted and executed inside the container, without requiring `fuze`.
After `package.sh` has been finished, its edited back to its original state.

PS: I prefer using highly explicit `sed` commands so only relevant parts are touched, hope its not considered bloat. :)