### PR TITLE
ci/release: remove version part from glob

### DIFF
--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -7,14 +7,14 @@ runs:
     - name: Download AppImage artifacts
       uses: actions/download-artifact@v4
       with:
-        pattern: ungoogled-chromium-${{ steps.version.outputs.version }}-*-AppImage
+        pattern: ungoogled-chromium-*-AppImage
         path: ./release/
         merge-multiple: true
 
     - name: Download tar.xz artifacts
       uses: actions/download-artifact@v4
       with:
-        pattern: ungoogled-chromium-${{ steps.version.outputs.version }}-*-linux
+        pattern: ungoogled-chromium-*-linux
         path: ./release/
         merge-multiple: true
 


### PR DESCRIPTION
In aa831f0eb4c2b5d7a8e27f53f688f8abafa22977, I removed the step that computes the tag/version from `chromium_version.txt`, but forgot to stop using it when downloading artifacts.

This should fix it, so that the release step works on next update.