### PR TITLE
ci/import-cache: wait for `rm -rf` to finish before proceeding

### DIFF
--- a/.github/scripts/import-cache.sh
+++ b/.github/scripts/import-cache.sh
@@ -8,7 +8,7 @@ sudo rm -rf /usr/local/lib/android \
             /usr/lib/jvm \
             /usr/lib/google-cloud-sdk \
             /usr/lib/dotnet \
-            /usr/share/swift &
+            /usr/share/swift
 
 _base_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && cd ../.. && pwd)"
 _cache_tar="$_base_dir/.github/cache/build-cache-$ARCH.tar.zst"
@@ -18,4 +18,3 @@ zstd -d -c "${_cache_tar}" | tar -xf - -C "${_base_dir}"
 # we no longer need the tarball once it's
 # extracted, so let's get rid of it
 rm "${_cache_tar}"
-wait


### PR DESCRIPTION
Since we are deleting stuff in the background while extracting, there is a chance that the extraction runs faster than the deletions, and the runner will run out of space before the extraction is complete.

This will make the extraction take slightly longer, but it should resolve this problem.