### PR TITLE
Fix potential issue with docker cache

### DIFF
--- a/docker/build.Dockerfile
+++ b/docker/build.Dockerfile
@@ -7,7 +7,7 @@ RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selectio
 RUN apt-get -y update && apt-get -y upgrade
 
 # install latest nodejs lts version
-RUN apt-get install -y apt-transport-https ca-certificates curl gnupg &&\
+RUN apt-get -y update && apt-get install -y apt-transport-https ca-certificates curl gnupg &&\
   curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash -
 RUN apt-get -y update && apt-get -y install nodejs && npm update -g npm
 


### PR DESCRIPTION
Docker build can fail due to using old cached packages when `get-apt update` is not run on the same line.